### PR TITLE
Fix difference in error message compared to proc-macro-error

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -530,7 +530,7 @@ pub mod __export {
                 None => Span::call_site(),
             };
 
-            let last = match ts.next() {
+            let last = match ts.last() {
                 Some(t) => t.span(),
                 None => first,
             };

--- a/tests/ui/multiple_tokens.stderr
+++ b/tests/ui/multiple_tokens.stderr
@@ -2,4 +2,4 @@ error: ...
  --> tests/ui/multiple_tokens.rs:2:1
   |
 2 | type T = ();
-  | ^^^^^^
+  | ^^^^^^^^^^^^

--- a/tests/ui/to_tokens_span.stderr
+++ b/tests/ui/to_tokens_span.stderr
@@ -2,7 +2,7 @@ error: whole type
  --> tests/ui/to_tokens_span.rs:3:17
   |
 3 | to_tokens_span!(std::option::Option);
-  |                 ^^^^
+  |                 ^^^^^^^^^^^^^^^^^^^
 
 error: explicit .span()
  --> tests/ui/to_tokens_span.rs:3:17


### PR DESCRIPTION
I experienced a difference in the error messages compared to proc-macro-error (- is proc-macro-error, + is proc-macro-error2)

```diff
 103 |     #[benches::my_id(file = String::from("iai-callgrind/tests/fixtures/numbers.fix"))]
-    |                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    |                             ^^^^^^^
 
 109 |     #[benches::my_id(file = String::from("iai-callgrind/tests/fixtures/numbers.fix"))]
-    |                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    |                             ^^^^^^^

 3 | #[library_benchmark(wrong = LibraryBenchmarkConfig::default())]
-  |                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  |                     ^^^^^^^
 
 4 | #[bench::id(invalid = "value")]
-  |             ^^^^^^^^^^^^^^^^^
+  |             ^^^^^^^^^
 
 8 | #[bench::id(wrong = LibraryBenchmarkConfig::default())]
-  |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  |             ^^^^^^^

 16 | #[benches::wrong(wrong = LibraryBenchmarkConfig::default())]
-   |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |                  ^^^^^^^
```

These diffs are excerpts from the error messages [here](https://github.com/iai-callgrind/iai-callgrind/actions/runs/10740773329/job/29789694576) if you need the full error messages.

UPDATE:

Sorry, I haven't read #1 thoroughly enough and my original description of this pr was wrong.