### PR TITLE
Added `with_proc_macro_error` function that works with proc_macro2 streams

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -286,7 +286,7 @@ use proc_macro2::Span;
 use quote::{quote, ToTokens};
 
 use std::cell::Cell;
-use std::panic::{catch_unwind, resume_unwind, AssertUnwindSafe, UnwindSafe};
+use std::panic::{catch_unwind, resume_unwind, UnwindSafe};
 
 pub mod dummy;
 
@@ -492,7 +492,7 @@ where
     F: FnOnce() -> proc_macro2::TokenStream + UnwindSafe,
 {
     ENTERED_ENTRY_POINT.with(|flag| flag.set(flag.get() + 1));
-    let caught = catch_unwind(AssertUnwindSafe(f));
+    let caught = catch_unwind(f);
     let dummy = dummy::cleanup();
     let err_storage = imp::cleanup();
     ENTERED_ENTRY_POINT.with(|flag| flag.set(flag.get() - 1));


### PR DESCRIPTION
This is an alternative to the #[proc_macro_error] attribute, meant to be used in unit tests. It is basically the entry_point() function but using proc_macro2 streams and with the removed proc_macro_hack code. 